### PR TITLE
Add python3 shebang

### DIFF
--- a/dkb2homebank.py
+++ b/dkb2homebank.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import argparse
 import csv

--- a/dkb2homebankTest.py
+++ b/dkb2homebankTest.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 from builtins import ResourceWarning
 import unittest
 import dkb2homebank


### PR DESCRIPTION
These scripts are written for python3. If started with python2 the following error messages occur:

      File "./dkb2homebank.py", line 82, in convert_visa
        with open(filename, 'r', encoding='iso-8859-1') as csvfile:
    TypeError: 'encoding' is an invalid keyword argument for this function

    Traceback (most recent call last):
      File "dkb2homebankTest.py", line 1, in <module>
        from builtins import ResourceWarning
    ImportError: cannot import name ResourceWarning

So make sure that the correct python version is taken. Additionally make the test file executable as it has a main function.