### PR TITLE
Update cash export file format which is now the same as giro export

### DIFF
--- a/dkb2homebank.py
+++ b/dkb2homebank.py
@@ -97,7 +97,7 @@ def detect_csv_format(file_path):
         return CsvFileTypes.CASH
     
     # "Konto" is the old-style export, "Girokonto" was introduced around November 2024
-    if header.startswith("\"Konto\"") or header.startswith("\"Girokonto\""):
+    if header.startswith("\"Konto\"") or header.startswith("\"Girokonto\"") or header.startswith("\"Tagesgeld\""):
         return CsvFileTypes.GIRO
 
     if header.startswith("\"Karte\""):


### PR DESCRIPTION
The cash savings / Tagesgeld exports now use the same format as the giro ones, with a header starting with "Tagesgeld".